### PR TITLE
Update readme with fancy badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # [NoCubes Mod](https://Cadiboo.github.io/projects/nocubes/)
+
+[![Curseforge Downloads](http://cf.way2muchnoise.eu/full_nocubes_downloads.svg)
+![Curseforge Versions](http://cf.way2muchnoise.eu/versions/nocubes.svg)](https://www.curseforge.com/minecraft/mc-mods/nocubes)
+
 A mod for 1.12.2+ by [Cadiboo](https://github.com/Cadiboo) that creates smooth terrain in Minecraft.  
 [Website](https://Cadiboo.github.io/projects/nocubes/)  
 [CurseForge Page](https://minecraft.curseforge.com/projects/nocubes)  


### PR DESCRIPTION
Preview:

[![Curseforge Downloads](http://cf.way2muchnoise.eu/full_nocubes_downloads.svg) ![Curseforge Versions](http://cf.way2muchnoise.eu/versions/nocubes.svg)](https://www.curseforge.com/minecraft/mc-mods/nocubes)

I think a discord badge could also be added. It looks like this:

[![Discord](https://img.shields.io/discord/297104769649213441?label=Discord)
](https://discordapp.com/invite/QXbWS36)

This is the code:
```
[![Discord](https://img.shields.io/discord/297104769649213441?label=Discord)](https://discordapp.com/invite/zKP8EgY)
```
The number has to be replaced with the server id, but only the server owner has access to that.
[Here is a guide on how to retrieve it.](https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord#get-the-channel-id-of-the-discord-text-channel)

Inspiration: [The Useful-Backpacks github.](https://github.com/MC-U-Team/Useful-Backpacks)